### PR TITLE
Fixes typo in features description

### DIFF
--- a/apps/docs/src/components/home/features.astro
+++ b/apps/docs/src/components/home/features.astro
@@ -43,5 +43,5 @@ const features: ListItem[] = [
 <SectionList
   listItems={features}
   title="Why Vexilla?"
-  description="Besides just the things that feaure flags themselves offer, Vexilla allows you to do more with less. Here is what separates us from other feature flag tools."
+  description="Besides just the things that feature flags themselves offer, Vexilla allows you to do more with less. Here is what separates us from other feature flag tools."
 />


### PR DESCRIPTION
Fixes typo on website where "feature flags" is mispelled as "feaure flags"